### PR TITLE
Adds select() to the AnnDataset trait

### DIFF
--- a/src/data/in_memory_dataset.rs
+++ b/src/data/in_memory_dataset.rs
@@ -51,6 +51,10 @@ impl<DataType: Clone + H5Type> AnnDataset<DataType> for InMemoryAnnDataset<DataT
         &self.data_points
     }
 
+    fn select(&self, ids: &[usize]) -> PointSet<DataType> {
+        self.data_points.select(ids)
+    }
+
     fn iter<'a>(&'a self) -> impl Iterator<Item = &'a PointSet<DataType>>
     where
         DataType: 'a,

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -10,6 +10,9 @@ pub trait AnnDataset<DataType: Clone> {
     /// Returns all data points.
     fn get_data_points(&self) -> &PointSet<DataType>;
 
+    /// Selects a subset of data points.
+    fn select(&self, ids: &[usize]) -> PointSet<DataType>;
+
     /// Iterates over chunks of data points.
     fn iter<'a>(&'a self) -> impl Iterator<Item = &'a PointSet<DataType>>
     where


### PR DESCRIPTION
The select() operator at the AnnDataset trait level allows one to obtain a copy of a subset of data points. This enables point reads even if the AnnDataset itself is not available entirely in memory; a functionality that PointSet::select() does not currently facilitate.