### PR TITLE
Add mutable getter for point sets

### DIFF
--- a/src/data/in_memory_dataset.rs
+++ b/src/data/in_memory_dataset.rs
@@ -51,6 +51,10 @@ impl<DataType: Clone + H5Type> AnnDataset<DataType> for InMemoryAnnDataset<DataT
         &self.data_points
     }
 
+    fn get_data_points_mut(&mut self) -> &mut PointSet<DataType> {
+        &mut self.data_points
+    }
+
     fn select(&self, ids: &[usize]) -> PointSet<DataType> {
         self.data_points.select(ids)
     }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -10,6 +10,9 @@ pub trait AnnDataset<DataType: Clone> {
     /// Returns all data points.
     fn get_data_points(&self) -> &PointSet<DataType>;
 
+    /// Returns a mutable view of all data points.
+    fn get_data_points_mut(&mut self) -> &mut PointSet<DataType>;
+
     /// Selects a subset of data points.
     fn select(&self, ids: &[usize]) -> PointSet<DataType>;
 
@@ -44,7 +47,7 @@ pub trait AnnDataset<DataType: Clone> {
         self.get_query_set(TRAIN_QUERY_SET)
     }
 
-    /// Convenience method that returns the "train" `QuerySet`.
+    /// Convenience method that returns the "validation" `QuerySet`.
     fn get_validation_query_set(&self) -> anyhow::Result<&QuerySet<DataType>> {
         self.get_query_set(VALIDATION_QUERY_SET)
     }


### PR DESCRIPTION
Introduces a mutable getter for PointSet to the AnnDataset trait. It enables invocation of in-place l2_normalization of a point set, which is useful for cosine search.