### PR TITLE
Remove type restrictions

### DIFF
--- a/src/data/in_memory_dataset.rs
+++ b/src/data/in_memory_dataset.rs
@@ -11,12 +11,12 @@ const QUERY_SETS: &str = "query_sets";
 
 /// An ANN dataset.
 #[derive(Eq, PartialEq, Debug, Clone)]
-pub struct InMemoryAnnDataset<DataType: Clone + H5Type> {
+pub struct InMemoryAnnDataset<DataType: Clone> {
     data_points: PointSet<DataType>,
     query_sets: HashMap<String, QuerySet<DataType>>,
 }
 
-impl<DataType: Clone + H5Type> InMemoryAnnDataset<DataType> {
+impl<DataType: Clone> InMemoryAnnDataset<DataType> {
     /// Creates an `AnnDataset` object.
     ///
     /// Here is a simple example:
@@ -46,7 +46,7 @@ impl<DataType: Clone + H5Type> InMemoryAnnDataset<DataType> {
     }
 }
 
-impl<DataType: Clone + H5Type> AnnDataset<DataType> for InMemoryAnnDataset<DataType> {
+impl<DataType: Clone> AnnDataset<DataType> for InMemoryAnnDataset<DataType> {
     fn get_data_points(&self) -> &PointSet<DataType> {
         &self.data_points
     }
@@ -153,7 +153,7 @@ impl<DataType: Clone + H5Type> Hdf5File for InMemoryAnnDataset<DataType> {
     }
 }
 
-impl<DataType: Clone + H5Type> fmt::Display for InMemoryAnnDataset<DataType> {
+impl<DataType: Clone> fmt::Display for InMemoryAnnDataset<DataType> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,

--- a/src/types/point_set.rs
+++ b/src/types/point_set.rs
@@ -271,7 +271,7 @@ impl<DataType: Clone + H5Type> Hdf5Serialization for PointSet<DataType> {
     }
 }
 
-impl<DataType: Clone + H5Type> Display for PointSet<DataType> {
+impl<DataType: Clone> Display for PointSet<DataType> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let dense = match self.dense.as_ref() {
             None => "is empty".to_string(),

--- a/src/types/query_set.rs
+++ b/src/types/query_set.rs
@@ -104,7 +104,7 @@ impl<DataType: Clone + H5Type> Hdf5Serialization for QuerySet<DataType> {
     }
 }
 
-impl<DataType: Clone + H5Type> Display for QuerySet<DataType> {
+impl<DataType: Clone> Display for QuerySet<DataType> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,


### PR DESCRIPTION
Some of the impl clauses erroneously restricted the DataType to be H5Type. This patch removes such instances. (H5Type is only necessary for hdf5 serializer.)